### PR TITLE
Ri 2/cuadro sugerencias

### DIFF
--- a/app/Http/Controllers/MeetingSecretaryController.php
+++ b/app/Http/Controllers/MeetingSecretaryController.php
@@ -548,7 +548,8 @@ class MeetingSecretaryController extends Controller
                 'meeting_minutes_id' => $meeting_minutes->id,
                 'title' => $point['title'],
                 'duration' => $point['duration'] == '' ? 0 : $point['duration'],
-                'description' => $point['description']
+                'description' => $point['description'],
+                'sugerencia' => $point['sugerencia']
             ]);
 
             foreach ($point['agreements'] as $agreement) {
@@ -609,6 +610,7 @@ class MeetingSecretaryController extends Controller
                 'title' => $point->title,
                 'description' => $point->description,
                 'duration' => $point->duration,
+                'sugerencia' => $point->sugerencia,
                 'agreements' => $agreements_array
             );
 
@@ -712,7 +714,8 @@ class MeetingSecretaryController extends Controller
                 'meeting_minutes_id' => $meeting_minutes->id,
                 'title' => $point['title'],
                 'duration' => $point['duration'] == '' ? 0 : $point['duration'],
-                'description' => $point['description']
+                'description' => $point['description'],
+                'sugerencia' =>$point['sugerencia'],
             ]);
 
             foreach ($point['agreements'] as $agreement) {

--- a/app/Models/Point.php
+++ b/app/Models/Point.php
@@ -12,7 +12,8 @@ class Point extends Model
         'meeting_minutes_id',
         'title',
         'duration',
-        'description'
+        'description',
+        'sugerencia'
     ];
 
     public function meeting_minutes()

--- a/database/migrations/develop/2020_06_24_011024_create_point_table.php
+++ b/database/migrations/develop/2020_06_24_011024_create_point_table.php
@@ -22,6 +22,7 @@ class CreatePointTable extends Migration
             $table->string('title');
             $table->integer('duration')->nullable();
             $table->text('description')->nullable();
+            $table->text('sugerencia')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/develop/2020_06_24_012124_create_agreement_table.php
+++ b/database/migrations/develop/2020_06_24_012124_create_agreement_table.php
@@ -21,6 +21,7 @@ class CreateAgreementTable extends Migration
                 ->on('points')->onDelete('cascade');
             $table->string('identificator')->nullable();
             $table->text('description');
+            $table->text('sugerencia');
             $table->timestamps();
         });
     }

--- a/resources/views/meeting/minutes_create_step3.blade.php
+++ b/resources/views/meeting/minutes_create_step3.blade.php
@@ -342,6 +342,10 @@
                                                                                 <label>Descripción</label>
                                                                                 <textarea class="form-control point_description" rows="3" placeholder="Añade una descripción concisa del desarrollo de este punto">{{$point['description']}}</textarea>
                                                                             </div>
+                                                                            <div class="form-group">
+                                                                                <label>Sugerencias</label>
+                                                                                <textarea class="form-control point_sugerencia" rows="3" placeholder="Añade todas las sugerencias propuestas en caso de no llegar a un acuerdo">{{$point['sugerencia']}}</textarea>
+                                                                            </div>
                                                                         </div>
                                                                     </div>
 
@@ -432,6 +436,10 @@
                                                                                 <div class="form-group">
                                                                                     <label>Descripción</label>
                                                                                     <textarea class="form-control point_description" rows="3" placeholder="Añade una descripción concisa del desarrollo de este punto"></textarea>
+                                                                                </div>
+                                                                                <div class="form-group">
+                                                                                    <label>Sugerencias</label>
+                                                                                    <textarea class="form-control point_sugerencia" rows="3" placeholder="Añade las sugerencias propuestas en caso de no llegar a un acuerdo"></textarea>
                                                                                 </div>
                                                                             </div>
                                                                         </div>
@@ -591,7 +599,11 @@
                     // descripción del punto
                     let point_description = $this.find('.point_description').val();
                     item ["description"] = point_description;
-
+                    
+                    // sugerencias del punto
+                    let point_sugerencia = $this.find('.point_sugerencia').val();
+                    item ["sugerencia"] = point_sugerencia;
+                    
                     // acuerdos del punto
                     agreements = []
                     $this.find('.point_agreement').each(function(){
@@ -706,6 +718,12 @@
                                 <div class="form-group">
                                     <label>Descripción</label>
                                     <textarea class="form-control point_description" rows="3" placeholder="Añade una descripción concisa del desarrollo de este punto"></textarea>
+                                </div>
+                            </div>
+                            <div class="col-sm-12">
+                                <div class="form-group">
+                                    <label>Sugerencia</label>
+                                    <textarea class="form-control point_sugerencia" rows="3" placeholder="Sugerencias propuestas en caso de no llegar a un acuerdo"></textarea>
                                 </div>
                             </div>
                         </div>

--- a/resources/views/meeting/minutes_edit.blade.php
+++ b/resources/views/meeting/minutes_edit.blade.php
@@ -265,6 +265,10 @@
                                                             <label>Descripción</label>
                                                             <textarea class="form-control point_description" rows="3" placeholder="Añade una descripción concisa del desarrollo de este punto">{{$point['description']}}</textarea>
                                                         </div>
+                                                        <div class="form-group">
+                                                            <label>Sugerencias</label>
+                                                            <textarea class="form-control point_sugerencia" rows="3" placeholder="Añade todas las sugerencias propuestas en caso de no llegar a un acuerdo">{{$point['sugerencia']}}</textarea>
+                                                        </div>
                                                     </div>
                                                 </div>
 
@@ -422,6 +426,10 @@
                             let point_description = $this.find('.point_description').val();
                             item ["description"] = point_description;
 
+                            // sugerencia del punto
+                            let point_sugerencia = $this.find('.point_sugerencia').val();
+                            item ["sugerencia"] = point_sugerencia;
+
                             //no se como cambiar esto
                             // acuerdos del punto
                             agreements = []
@@ -537,6 +545,10 @@
                                         <div class="form-group">
                                             <label>Descripción</label>
                                             <textarea class="form-control point_description" rows="3" placeholder="Añade una descripción concisa del desarrollo de este punto"></textarea>
+                                        </div>
+                                        <div class="form-group">
+                                            <label>Sugerencias</label>
+                                            <textarea class="form-control point_sugerencia" rows="3" placeholder="Añade todas las sugerencias propuestas en caso de no llegar a un acuerdo">{{$point['sugerencia']}}</textarea>
                                         </div>
                                     </div>
                                 </div>

--- a/resources/views/meeting/minutes_edit.blade.php
+++ b/resources/views/meeting/minutes_edit.blade.php
@@ -422,6 +422,7 @@
                             let point_description = $this.find('.point_description').val();
                             item ["description"] = point_description;
 
+                            //no se como cambiar esto
                             // acuerdos del punto
                             agreements = []
                             $this.find('.point_agreement').each(function(){

--- a/resources/views/meeting/minutes_template.blade.php
+++ b/resources/views/meeting/minutes_template.blade.php
@@ -246,6 +246,12 @@
                     </p>
                 @endif
 
+                @if($point->sugerencia)
+                    <p style="text-align: justify">
+                        {{$point->sugerencia}}
+                    </p>
+                @endif
+
                 @if($point->agreements->count() > 0)
 
                     <table>


### PR DESCRIPTION
Nuestra tarea ha consistido en incorporar un atributo llamado 'Sugerencia' a la hora de crear una acta, dada una convocatoria creada previamente. A su vez, hemos dispuesto este atributo tanto en la vista de 'Crear acta' como en la de editar una ya existente. Además, el resto de operaciones _CRUD_ funcionan satisfactoriamente.

En suma, en el documento PDF a generar del acta, se puede apreciar la sugerencia redactada en la segunda página pertinente al documento.